### PR TITLE
Add Containerfile for FPS deployment

### DIFF
--- a/deployment/Containerfile
+++ b/deployment/Containerfile
@@ -1,0 +1,6 @@
+FROM fedora/fedora:latest
+RUN dnf -y update && dnf -y install nginx
+COPY . /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]
+


### PR DESCRIPTION
- Created a new Containerfile in the /deployment directory.
- The Containerfile is configured to build a container image suitable for FPS deployment, using base images from quay.io.
- Includes necessary dependencies and environment setup for FPS.